### PR TITLE
Validate prereqs, make backend more error resilient

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -378,7 +378,7 @@ def addNewCourse():
         connection.rollback()
 
     for i in range(1, sections + 1):
-            cur.execute(sql.SQL("INSERT INTO courseoffering (coursecode, termcode, component, coursetype, enrlcap, proffirstname, proflastname) VALUES (%s, %s, %s, %s, %s, %s, %s);"), [course_code, term_code, i, course_types.split()[0], section_size, prof_first_name, prof_last_name])
+        cur.execute(sql.SQL("INSERT INTO courseoffering (coursecode, termcode, component, coursetype, enrlcap, proffirstname, proflastname) VALUES (%s, %s, %s, %s, %s, %s, %s);"), [course_code, term_code, i, course_types.split()[0], section_size, prof_first_name, prof_last_name])
     # Insert into coursegroups table and associate prerequisites
     for prereq in prereqs:
         cur.execute(sql.SQL("INSERT INTO courseGroup (quantity) VALUES (1);"))

--- a/backend/main.py
+++ b/backend/main.py
@@ -16,7 +16,7 @@ with open('./configs') as f:
     _port = f.readline().rstrip()
     connection_params = {
         "DB": _db,
-        "USER": "jamesdorfman",
+        "USER": _user,
         "PASSWORD": _pw,
         "HOST": _host,
         "PORT": _port

--- a/frontend/src/app/add-course/add-course.component.ts
+++ b/frontend/src/app/add-course/add-course.component.ts
@@ -73,8 +73,35 @@ export class AddCourseComponent implements OnInit {
     }
 
     this.prereqsList.length = 0;
+    this.prereqsList.length = 0;
     for (const val of (this.inputForm.controls.prereqList as FormArray).controls) {
-      this.prereqsList.push((val as FormGroup).controls.prereq.value);
+      var prereq = (val as FormGroup).controls.prereq.value;
+
+      if(prereq.length == 0){
+        // If the user just added an extra prereq slot and never filled it out, ignore it
+        continue;
+      }
+
+      var verified = false;
+
+      // Verify that the prereq is valid
+      var xhttp = new XMLHttpRequest();
+      xhttp.onreadystatechange = function() {
+        if(this.readyState == 4 && this.responseText != "{}"){
+          console.log("Course verification response " + this.responseText);
+          verified = true;
+          return;
+        } 
+      };
+      var url = `${urlConfig.baseUrl}/getCourseInfo?course=${encodeURIComponent(prereq)}`
+      xhttp.open("GET", url, false); // false ==> don't make an async task (do it synchronously)
+      xhttp.send();
+      
+      if(!verified){
+        this.validationMsg = `Seems like the course ${prereq} does not exist`
+        return;
+      }
+      this.prereqsList.push(prereq);
     }
 
     this.api

--- a/frontend/src/app/degreeReq/degreeReq.component.ts
+++ b/frontend/src/app/degreeReq/degreeReq.component.ts
@@ -36,7 +36,7 @@ export class CoursePathComponent implements OnInit {
     .subscribe(res => {
       console.log(res)
       if (Object.keys(res).length === 0 && res.constructor === Object){
-        this.errorCourseAdd = `Seems like the course ${course} does not exist`
+        this.errorCourseAdd = `Seems like the prerequisite ${course} does not exist`
         return;
       }
       this.errorCourseAdd = ''


### PR DESCRIPTION
Changes

Frontend:
* Validate that prereqs are real courses before making the course

Backend:
* Change `list` -> `lst` so that Python would let me use the function `list`, which I needed for filtering stuff.
* Stop requiring termcodes to be unique when adding courses
* Enable a course to have no prereqs (that's what the prereq filter is there for)
